### PR TITLE
chore(angular): update dependencies to version 19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Please use **one** of these scopes when fitting:
 - **java-script**: changes affect [java-script](libs/java-script)
 - **type-script**: changes affect [type-script](libs/type-script)
 - **vue**: changes affect [vue](libs/vue)
+- **angular**: changes affect [vue](libs/angular)
 
 ## Pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Please use **one** of these scopes when fitting:
 - **java-script**: changes affect [java-script](libs/java-script)
 - **type-script**: changes affect [type-script](libs/type-script)
 - **vue**: changes affect [vue](libs/vue)
-- **angular**: changes affect [vue](libs/angular)
+- **angular**: changes affect [angular](libs/angular)
 
 ## Pull request
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+### Creating a new version after rule changes
+
+1. Go into the changed pacakge
+2. Update [CHANGELOG.md](CHANGELOG.md).
+3. Run `npm version [<newversion> | major | minor | patch] -m "feat(<package>): <versionmessage>"`.
+4. Push commits and tags using `git push --tags && git push`.
+5. Run `npm publish --access public` to publish the new version to npm.

--- a/libs/angular/CHANGELOG.md
+++ b/libs/angular/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## v19.0.0
 
+### ⚠️ Breaking Changes
+- ⚠️ eslint-plugin: add prefer-signals rule to exported config ([#2150](https://github.com/angular-eslint/angular-eslint/pull/2150))
+- ⚠️ eslint-plugin: remove deprecated no-host-metadata-property rule ([#2113](https://github.com/angular-eslint/angular-eslint/pull/2113))
+
+### 🩹 Fixes
 - update angular packages to v19.0.0 (#10)
 - update typescript-eslint packages to v8.18.0
 - update dependency eslint to v9.16.0
-- eslint-plugin: remove deprecated no-host-metadata-property rule ([#2113](https://github.com/angular-eslint/angular-eslint/pull/2113))
-- eslint-plugin: add prefer-signals rule to exported config ([#2150](https://github.com/angular-eslint/angular-eslint/pull/2150))
 
 ## v18.0.2
 

--- a/libs/angular/CHANGELOG.md
+++ b/libs/angular/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## v19.0.0
+
+### Angular
+- update angular packages to v19.0.0 (#10)
+- update typescript-eslint packages to v8.18.0
+- update dependency eslint to v9.16.0
+- eslint-plugin: remove deprecated no-host-metadata-property rule ([#2113](https://github.com/angular-eslint/angular-eslint/pull/2113))
+- eslint-plugin: add prefer-signals rule to exported config ([#2150](https://github.com/angular-eslint/angular-eslint/pull/2150))
+
 ## v18.0.2
 
 - Fix homepage url in package.json

--- a/libs/angular/CHANGELOG.md
+++ b/libs/angular/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## v19.0.0
 
-### Angular
 - update angular packages to v19.0.0 (#10)
 - update typescript-eslint packages to v8.18.0
 - update dependency eslint to v9.16.0

--- a/libs/angular/README.md
+++ b/libs/angular/README.md
@@ -77,12 +77,3 @@ export default [
         })),
 ];
 ```
-
-## Development
-
-### Creating a new version after rule changes
-
-1. Update CHANGELOG.md.
-2. Run npm version [<newversion> | major | minor | patch] -m "feat(core): <versionmessage>".
-3. Push commits and tags.
-4. Run npm publish --access public to publish the new version to npm.

--- a/libs/angular/RELEASE.md
+++ b/libs/angular/RELEASE.md
@@ -1,0 +1,6 @@
+### Creating a new version after rule changes
+
+1. Update [CHANGELOG.md](CHANGELOG.md).
+2. Run `npm version [<newversion> | major | minor | patch] -m "feat(angular): <versionmessage>"`.
+3. Push commits and tags using `git push --tags && git push`.
+4. Run `npm publish --access public` to publish the new version to npm.

--- a/libs/angular/package.json
+++ b/libs/angular/package.json
@@ -35,17 +35,17 @@
         "default": "./dist/mjs/index.cjs"
     },
     "dependencies": {
-        "angular-eslint": "^18.3.0",
-        "typescript-eslint": "^8.1.0"
+        "angular-eslint": "^19.0.2",
+        "typescript-eslint": "^8.18.0"
     },
     "devDependencies": {
-        "@angular/core": "^18.2.0",
+        "@angular/core": "^19.0.0",
         "@types/eslint": "^8.56.11",
         "@types/eslint__eslintrc": "^2.1.2",
         "@types/eslint__js": "^8.42.3",
         "tsc-multi": "^1.1.0"
     },
     "peerDependencies": {
-        "eslint": "^9.9.0"
+        "eslint": "^9.16.0"
     }
 }

--- a/libs/angular/src/config/angular-config.ts
+++ b/libs/angular/src/config/angular-config.ts
@@ -28,7 +28,6 @@ const typescriptConfig = tseslint.config({
         '@angular-eslint/directive-selector': 'error',
         '@angular-eslint/no-attribute-decorator': 'error',
         '@angular-eslint/no-conflicting-lifecycle': 'error',
-        '@angular-eslint/no-host-metadata-property': 'error',
         '@angular-eslint/no-input-prefix': 'error',
         '@angular-eslint/no-input-rename': 'error',
         '@angular-eslint/no-inputs-metadata-property': 'error',
@@ -45,6 +44,7 @@ const typescriptConfig = tseslint.config({
         '@angular-eslint/use-component-view-encapsulation': 'error',
         '@angular-eslint/use-lifecycle-interface': 'error',
         '@angular-eslint/use-pipe-transform-interface': 'error',
+        '@angular-eslint/prefer-signals': ['error'],
     },
 });
 


### PR DESCRIPTION
### Summary of Changes

- update dependencies of angular package to support version 19 of the frameworks

### Additional Notes

- removed deprecated rule `no-host-metadata-property`
- add new rule `prefer-signals`

Closes #10 